### PR TITLE
Move the script tag to come at the end of the body

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-custom-css",
 	"displayName": "Custom CSS and JS Loader",
 	"description": "Custom CSS and JS for Visual Studio Code",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"publisher": "be5invis",
 	"author": {
 		"email": "belleve@typeof.net",
@@ -39,7 +39,17 @@
 				"command": "extension.updateCustomCSS",
 				"title": "Update Custom CSS and JS"
 			}
-		]
+		],
+		"configuration": {
+			"title": "Custom CSS/JS Configuration",
+			"properties": {
+				"vscode_custom_css.imports": {
+					"title": "Custom CSS/JS files, as an array of URLs, not file paths",
+					"type": "array",
+					"default": []
+				}
+			}
+		}
 	},
 	"devDependencies": {
 		"mustache": "^2.2.1",

--- a/src/extension.js
+++ b/src/extension.js
@@ -45,8 +45,8 @@ function activate(context) {
 		try {
 			var html = fs.readFileSync(htmlFile, 'utf-8');
 			html = html.replace(/<!-- !! VSCODE-CUSTOM-CSS-START !! -->[\s\S]*?<!-- !! VSCODE-CUSTOM-CSS-END !! -->/, '');
-			html = html.replace(/(<\/body>)/,
-				'<!-- !! VSCODE-CUSTOM-CSS-START !! -->' + injectHTML + '<!-- !! VSCODE-CUSTOM-CSS-END !! -->');
+			html = html.replace(/(<\/html>)/,
+				'<!-- !! VSCODE-CUSTOM-CSS-START !! -->' + injectHTML + '<!-- !! VSCODE-CUSTOM-CSS-END !! --></html>');
 			fs.writeFileSync(htmlFile, html, 'utf-8');
 			enabledRestart();
 		} catch (e) {


### PR DESCRIPTION
I wanted to do some work in the JS after the app has loaded (then you get access to the `vscode` global. 

So I've moved the insertion to be after the end of body, as the index.js is being inserted after the custom JS. 

This also adds `vscode_custom_css.imports` to the preferences autocomplete too :)