### PR TITLE
Allow external resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-custom-css",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,73 +1,74 @@
 {
-	"name": "vscode-custom-css",
-	"displayName": "Custom CSS and JS Loader",
-	"description": "Custom CSS and JS for Visual Studio Code",
-	"version": "2.6.1",
-	"publisher": "be5invis",
-	"author": {
-		"email": "belleve@typeof.net",
-		"name": "Belleve Invis",
-		"url": "https://typeof.net"
-	},
-	"engines": {
-		"vscode": "^1.9.1"
-	},
-	"categories": [
-		"Other",
-		"Themes"
-	],
-	"preview": true,
-	"icon": "images/logo.png",
-	"galleryBanner": {
-		"color": "#EEEEEE"
-	},
-	"activationEvents": [
-		"*"
-	],
-	"main": "./src/extension",
-	"contributes": {
-		"commands": [
-			{
-				"command": "extension.installCustomCSS",
-				"title": "Enable Custom CSS and JS"
-			},
-			{
-				"command": "extension.uninstallCustomCSS",
-				"title": "Disable Custom CSS and JS"
-			},
-			{
-				"command": "extension.updateCustomCSS",
-				"title": "Reload Custom CSS and JS"
-			}
-		],
-		"configuration": {
-			"title": "Custom CSS/JS Configuration",
-			"properties": {
-				"vscode_custom_css.imports": {
-					"description": "Custom CSS/JS files, as an array of URLs, not file paths",
-					"type": "array",
-					"default": []
-				},
-				"vscode_custom_css.statusbar": {
-					"description": "Enable Status Indicator",
-					"type": "boolean",
-					"default": true
-				},
-				"vscode_custom_css.policy": {
-					"description": "Disable vscode Content Policy (required if loading from URL)",
-					"type": "boolean",
-					"default": false
-				}
-			}
-		}
-	},
-	"devDependencies": {},
-	"dependencies": {
-		"file-url": "^2.0.2"
-	},
-	"__metadata": {
-		"id": "1b160753-ae5e-42bb-82ad-d115ce5c10f4",
-		"publisherDisplayName": "be5invis",
-		"publisherId": "8c148d69-cbc6-480b-bd8b-a42715926324"
-	}
+  "name": "vscode-custom-css",
+  "displayName": "Custom CSS and JS Loader",
+  "description": "Custom CSS and JS for Visual Studio Code",
+  "version": "2.6.1",
+  "publisher": "be5invis",
+  "author": {
+    "email": "belleve@typeof.net",
+    "name": "Belleve Invis",
+    "url": "https://typeof.net"
+  },
+  "engines": {
+    "vscode": "^1.9.1"
+  },
+  "categories": [
+    "Other",
+    "Themes"
+  ],
+  "preview": true,
+  "icon": "images/logo.png",
+  "galleryBanner": {
+    "color": "#EEEEEE"
+  },
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./src/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.installCustomCSS",
+        "title": "Enable Custom CSS and JS"
+      },
+      {
+        "command": "extension.uninstallCustomCSS",
+        "title": "Disable Custom CSS and JS"
+      },
+      {
+        "command": "extension.updateCustomCSS",
+        "title": "Reload Custom CSS and JS"
+      }
+    ],
+    "configuration": {
+      "title": "Custom CSS/JS Configuration",
+      "properties": {
+        "vscode_custom_css.imports": {
+          "description": "Custom CSS/JS files, as an array of URLs, not file paths",
+          "type": "array",
+          "default": []
+        },
+        "vscode_custom_css.statusbar": {
+          "description": "Enable Status Indicator",
+          "type": "boolean",
+          "default": true
+        },
+        "vscode_custom_css.policy": {
+          "description": "Disable vscode Content Policy (required if loading from URL)",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  },
+  "devDependencies": {},
+  "dependencies": {
+    "file-url": "^2.0.2",
+    "xmlhttprequest": "^1.8.0"
+  },
+  "__metadata": {
+    "id": "1b160753-ae5e-42bb-82ad-d115ce5c10f4",
+    "publisherDisplayName": "be5invis",
+    "publisherId": "8c148d69-cbc6-480b-bd8b-a42715926324"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,19 @@
 			"title": "Custom CSS/JS Configuration",
 			"properties": {
 				"vscode_custom_css.imports": {
-					"title": "Custom CSS/JS files, as an array of URLs, not file paths",
+					"description": "Custom CSS/JS files, as an array of URLs, not file paths",
 					"type": "array",
 					"default": []
+				},
+				"vscode_custom_css.statusbar": {
+					"description": "Enable Status Indicator",
+					"type": "boolean",
+					"default": true
+				},
+				"vscode_custom_css.policy": {
+					"description": "Disable vscode Content Policy (required if loading from URL)",
+					"type": "boolean",
+					"default": false
 				}
 			}
 		}

--- a/src/extension.js
+++ b/src/extension.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var events = require('events');
 var msg = require('./messages').messages;
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 var fileUrl = require('file-url');
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -6,9 +6,6 @@ var msg = require('./messages').messages;
 
 var fileUrl = require('file-url');
 
-const indicatorClass = '__CUSTOM_CSS_JS_INDICATOR_CLS'
-const indicatorJS = `<script src="${fileUrl(__dirname + '/statusbar.js')}"></script>`
-
 function activate(context) {
 
 	console.log('vscode-customcss is active!');
@@ -29,6 +26,16 @@ function activate(context) {
 	var htmlFile = base + (isWin ? '\\electron-browser\\bootstrap\\index.html' : '/electron-browser/bootstrap/index.html');
 	var htmlFileBack = base + (isWin ? '\\electron-browser\\bootstrap\\index.html.bak-customcss' : '/electron-browser/bootstrap/index.bak-customcss');
 
+	function httpGet(theUrl)
+	{
+		var xmlHttp = null;
+
+		xmlHttp = new XMLHttpRequest();
+		xmlHttp.open( "GET", theUrl, false );
+		xmlHttp.send( null );
+		return xmlHttp.responseText;
+	}
+
 	function replaceCss() {
 		var config = vscode.workspace.getConfiguration("vscode_custom_css");
 		console.log(config);
@@ -41,13 +48,27 @@ function activate(context) {
 		var injectHTML = config.imports.map(function (x) {
 			if (!x) return;
 			if (typeof x === 'string') {
-				if (/\.js$/.test(x)) return '<script src="' + x + '"></script>';
-				if (/\.css$/.test(x)) return '<link rel="stylesheet" type="text/css" href="' + x + '"/>';
+				if (/^file.*\.js$/.test(x)) return '<script src="' + x + '"></script>';
+				if (/^file.*\.css$/.test(x)) return '<link rel="stylesheet" href="' + x + '"/>';
+				if (/^http.*\.js$/.test(x)) return '<script>' + httpGet(x) + '</script>';
+				if (/^http.*\.css$/.test(x)) return '<style>' + httpGet(x) + '</style>';
 			}
 		}).join('');
 		try {
 			var html = fs.readFileSync(htmlFile, 'utf-8');
 			html = html.replace(/<!-- !! VSCODE-CUSTOM-CSS-START !! -->[\s\S]*?<!-- !! VSCODE-CUSTOM-CSS-END !! -->/, '');
+
+			if (config.policy) {
+				html = html.replace(/<meta.*http-equiv="Content-Security-Policy".*>/, '');
+			}
+
+			var indicatorClass = ''
+			var indicatorJS = ''
+			if (config.statusbar){
+				indicatorClass = '__CUSTOM_CSS_JS_INDICATOR_CLS'
+				indicatorJS = `<script src="${fileUrl(__dirname + '/statusbar.js')}"></script>`
+			}
+
 			html = html.replace(/(<\/html>)/,
 				'<!-- !! VSCODE-CUSTOM-CSS-START !! -->' + indicatorJS + injectHTML + '<!-- !! VSCODE-CUSTOM-CSS-END !! --></html>');
 			fs.writeFileSync(htmlFile, html, 'utf-8');


### PR DESCRIPTION
This allows for loading external resources which was previously prohibited by the content policy of vs-code, and thereby fixing [Issue #13 ](https://github.com/be5invis/vscode-custom-css/issues/30)

It also implements the option to disable the statusbar icon, and fixes the bug where the config descriptions wouldn't load.
