### PR TITLE
Allow data URIs to load

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -49,8 +49,8 @@ function activate(context) {
 		var injectHTML = config.imports.map(function (x) {
 			if (!x) return;
 			if (typeof x === 'string') {
-				if (/^file.*\.js$/.test(x)) return '<script src="' + x + '"></script>';
-				if (/^file.*\.css$/.test(x)) return '<link rel="stylesheet" href="' + x + '"/>';
+				if (/^(file)|(data).*\.js$/.test(x)) return '<script src="' + x + '"></script>';
+				if (/^(file)|(data).*\.css$/.test(x)) return '<link rel="stylesheet" href="' + x + '"/>';
 				if (/^http.*\.js$/.test(x)) return '<script>' + httpGet(x) + '</script>';
 				if (/^http.*\.css$/.test(x)) return '<style>' + httpGet(x) + '</style>';
 			}


### PR DESCRIPTION
It would be nice to add data URIs like this in the `vscode_custom_css.imports`: 
`data:text/css;base64,LndpbmRvd3N7Zm9udC1mYW1pbHk6Um9ib3RvIWltcG9ydGFudH0=`
(which will set the window font to Roboto)

And this is perfectly supported by:
- `<link rel="stylesheet" href="data:">`
- `<script src="data:"></script>`

That way I can store my CSS in my config file