### PR TITLE
Allow data URIs to load fixed again

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -56,12 +56,15 @@ function activate(context) {
 			.map(function(x) {
 				if (!x) return;
 				if (typeof x === "string") {
-					if (/^(file|data).*\.js$/.test(x))
+					if (/^((file:.*\.js)|(data:.*))$/.test(x))
 						return '<script src="' + x + '"></script>';
-					if (/^(file|data).*\.css$/.test(x))
+
+					if (/^((file:.*\.css)|(data:.*))$/.test(x))
 						return '<link rel="stylesheet" href="' + x + '"/>';
+
 					if (/^http.*\.js$/.test(x))
 						return "<script>" + httpGet(x) + "</script>";
+
 					if (/^http.*\.css$/.test(x))
 						return "<style>" + httpGet(x) + "</style>";
 				}


### PR DESCRIPTION
I'm really sorry that I broke your extension with my last pull request, I didn't mean to. I think I was very tired when I posted it. I updated the regex and here are some tests showing that it does work this time.

```js
// javascript

/^((file:.*\.js)|(data:.*))$/.test("file://home/maki/script.js")
true

/^((file:.*\.js)|(data:.*))$/.test("data:text/javascript;base64,YWxlcnQoInRlc3QiKQ==")
true

// css

/^((file:.*\.css)|(data:.*))$/.test("file://home/maki/script.css")
true

/^((file:.*\.css)|(data:.*))$/.test("data:text/css;base64,Ym9keXtiYWNrZ3JvdW5kOnJlZH0=")
true
```

![image](https://user-images.githubusercontent.com/8362329/65821199-45db1400-e22a-11e9-97ad-2a44f4098964.png)

![image](https://user-images.githubusercontent.com/8362329/65821208-5ee3c500-e22a-11e9-89f8-ed1733f5cca6.png)

```html
<html>
	<head>
		<link
			rel="stylesheet"
			href="data:text/css;base64,Ym9keXtiYWNrZ3JvdW5kOnJlZH0="
		/>
		<script src="data:text/javascript;base64,YWxlcnQoInRlc3QiKQ=="></script>
	</head>
</html>
```

![image](https://user-images.githubusercontent.com/8362329/65821257-1c6eb800-e22b-11e9-958a-f5c13b94652c.png)

Sorry for the inconvenience.
Thank you so much.