### PR TITLE
Fix readme to show both possible PATH values for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The placeholder `<Path to Visual Studio Code>` means the path to VSCode installa
 - `/Applications/Visual Studio Code.app/Contents/MacOS/Electron`, on MacOS;
 - `/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron`, on MacOS when using Insiders branch;
 - `/usr/share/code`, on most Linux;
-- `/usr/lib/code/` on Arch Linux.
+- `/usr/lib/code/` or `/opt/visual-studio-code` on Arch Linux.
 
 Mac and Linux package managers may have customized installation path. Please double check your path is correct.
 


### PR DESCRIPTION
Now it shows the path for the Code-OSS path and the path for the VSCode Studio version because they are different but this plugin works on both. 