### PR TITLE
Set extensionKind to "ui" for remoting support

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
 		"file-url": "^3.0.0",
 		"uuid": "^8.3.0",
 		"xmlhttprequest": "^1.8.0"
-	}
+	},
+	"extensionKind": ["ui"]
 }


### PR DESCRIPTION
Sets the extensionKind to ui to allow the extension to be used in remote development environments. This forces the extension to run as a UI extension (on the local machine) rather than a workspace extension (on the remote machine).

Reference: https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location

----

Exactly the same (description copied verbatim) as https://github.com/usernamehw/vscode-error-lens/pull/63, I did this since the value defaults to `"workspace"` if its unspecified which causes it to break in remote environments.