### PR TITLE
reduce error level for file not found

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -116,7 +116,7 @@ function activate(context) {
 		const injectHTML = await patchHtml(staging, config);
 		html = html.replace(/<meta.*http-equiv="Content-Security-Policy".*>/, "");
 
-              let indicatorJS = "";
+		let indicatorJS = "";
 		if (config.statusbar) indicatorJS = await getIndicatorJs();
 
 		html = html.replace(
@@ -191,8 +191,8 @@ function activate(context) {
 				console.log(`Unsupported extension type: ${ext}`);
 			}
 		} catch (e) {
-			vscode.window.showInformationMessage(msg.cannotLoad(url));
-			throw e;
+			vscode.window.showWarningMessage(msg.cannotLoad(url));
+			return "";
 		}
 	}
 	async function getIndicatorJs() {


### PR DESCRIPTION
When using settings sync between multiple platforms, paths for custom CSS may need to be different because of OS requirements.

This reduces the "can't load file" error from a fatal error to a warning.