### PR TITLE
allow html extension

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -166,6 +166,8 @@ function activate(context) {
 				return `<style>${fetched}</style>`;
 			} else if (ext === ".js") {
 				return `<script>${fetched}</script>`;
+			} else if (ext === ".html") {
+				return `${fetched}`;
 			} else {
 				console.log(`Unsupported extension type: ${ext}`);
 			}


### PR DESCRIPTION
Allows for `.html` files to be included as well, and places them after the style and script tags in body.

My use case for this was an indicator box around the focused element:
`custom.html`:
```html
<div
  id="focus-border"
  class="focus-border"
  style="
    border: solid 2px #7f7f7f;
    position: absolute;
    left: 0;
    top: 0;
    width: 0px;
    z-index: 2;
    height: 0px;
    pointer-events: none;
    user-select: none;
    -moz-user-select: none;
    -khtml-user-select: none;
    -webkit-user-select: none;
    -o-user-select: none;
  "
></div>
```
`indicator.js`:
```js
for (element of document.querySelectorAll("*")) {
  element.addEventListener("focusin", moveFocusBorder);
}

window.addEventListener("blur", moveFocusBorder);

function moveFocusBorder() {
  for (element of document.querySelectorAll(
    ".panel,.sidebar,.editor-group-container"
  )) {
    if (
      (element === document.activeElement ||
        element.contains(document.activeElement)) &&
      document.hasFocus()
    ) {
      let rect = element.getBoundingClientRect();

      document.getElementById("focus-border").style.left = rect.left + "px";
      document.getElementById("focus-border").style.top = rect.top + "px";
      document.getElementById("focus-border").style.width =
        rect.right - rect.left - 5 + "px";
      document.getElementById("focus-border").style.height =
        rect.bottom - rect.top + "px";
      break;
    }
  }
}
```

Example with terminal focused:
![image](https://user-images.githubusercontent.com/49327592/210155097-1297a32d-88b5-49fc-be90-a0a4a9cceae8.png)
