### PR TITLE
added classname for statusbar icon for alignment

### DIFF
--- a/src/statusbar.js
+++ b/src/statusbar.js
@@ -11,6 +11,7 @@
 			{
 				const a = document.createElement("a");
 				a.tabIndex = -1;
+				a.className = 'statusbar-item-label';
 				{
 					const span = document.createElement("span");
 					span.className = "codicon codicon-paintcan";


### PR DESCRIPTION
the classname 'statusbar-item-label' which is applied to all other statusbar element was missing which causes misalignment

before fix :
![image](https://github.com/be5invis/vscode-custom-css/assets/44346322/4a343630-8502-4958-8727-a4933c00bdde)

after fix :
![image](https://github.com/be5invis/vscode-custom-css/assets/44346322/9ac21768-83e2-4035-8f70-e2f3410dd287)
