### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ As you know to access the command palette and introduce commands you can use ***
 **You need to claim ownership on Visual Studio Code's installation directory, by running this command**:
 
 ```sh
-sudo chown -R $(whoami) $(which code)
+sudo chown -R $(whoami) "$(which code)"
 sudo chown -R $(whoami) /usr/share/code
 ```
 


### PR DESCRIPTION
On mac the path can be /Applications/Visual Studio Code.app/Contents/Resources/app/bin/code
Resulting in the error chown: /Applications/Visual: No such file or directory
The quotes fix this