### PR TITLE
Add ${workspaceFolder} variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ File URIs support VSCode variables like: `${userHome}`. It just replaces support
 - `${execPath}`
 - `${pathSeparator}`, `${/}`
 
+`${workspaceFolder}` represents to the root directory of the workspace currently open in VSCode.
 It also supports env variables like `${env:ENV_VAR_NAME}` and you can specify a fallback value like `${env:ENV_VAR:defaultvalue}`
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ File URIs support VSCode variables like: `${userHome}`. It just replaces support
 
 - `${cwd}`
 - `${userHome}`
+- `${workspaceFolder}`
 - `${execPath}`
 - `${pathSeparator}`, `${/}`
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -59,6 +59,7 @@ function activate(context) {
 		const variables = {
 			cwd: () => process.cwd(),
 			userHome: () => os.homedir(),
+			workspaceFolder: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "",
 			execPath: () => process.env.VSCODE_EXEC_PATH ?? process.execPath,
 			pathSeparator: () => path.sep,
 			"/": () => path.sep
@@ -189,10 +190,10 @@ function activate(context) {
 		html = html.replace(
 			/(<\/html>)/,
 			`<!-- !! VSCODE-CUSTOM-CSS-SESSION-ID ${uuidSession} !! -->\n` +
-				"<!-- !! VSCODE-CUSTOM-CSS-START !! -->\n" +
-				indicatorJS +
-				injectHTML +
-				"<!-- !! VSCODE-CUSTOM-CSS-END !! -->\n</html>"
+			"<!-- !! VSCODE-CUSTOM-CSS-START !! -->\n" +
+			indicatorJS +
+			injectHTML +
+			"<!-- !! VSCODE-CUSTOM-CSS-END !! -->\n</html>"
 		);
 		try {
 			await fs.promises.writeFile(htmlPath, html, "utf-8");
@@ -303,5 +304,5 @@ function activate(context) {
 exports.activate = activate;
 
 // this method is called when your extension is deactivated
-function deactivate() {}
+function deactivate() { }
 exports.deactivate = deactivate;


### PR DESCRIPTION
This PR introduces support for the ${workspaceFolder} variable in the _vscode_custom_css.imports_ configuration. It resolves to the path of the first workspace folder opened in VS Code.

### Changes

- Extended resolveVariable(key) in extension.js to handle ${workspaceFolder}.
- Updated documentation to list ${workspaceFolder} as a supported variable.

### Motivation
${workspaceFolder} is a commonly used placeholder in VS Code configurations. Supporting it allows users to write cleaner, more portable paths to their custom CSS/JS files relative to the current workspace.

`"vscode_custom_css.imports": [
  "file://${workspaceFolder}/.vscode/custom.css"
]
`