### PR TITLE
fix: inject CSS into <head> for auxiliary window support

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -187,14 +187,20 @@ function activate(context) {
 		let indicatorJS = "";
 		if (config.statusbar) indicatorJS = await getIndicatorJs();
 
+		// Inject into <head> so auxiliary windows (like New Chat Window) can clone the styles
 		html = html.replace(
-			/(<\/html>)/,
+			/(<\/head>)/,
 			`<!-- !! VSCODE-CUSTOM-CSS-SESSION-ID ${uuidSession} !! -->\n` +
-			"<!-- !! VSCODE-CUSTOM-CSS-START !! -->\n" +
-			indicatorJS +
-			injectHTML +
-			"<!-- !! VSCODE-CUSTOM-CSS-END !! -->\n</html>"
+				"<!-- !! VSCODE-CUSTOM-CSS-START !! -->\n" +
+				injectHTML +
+				"<!-- !! VSCODE-CUSTOM-CSS-END !! -->\n</head>"
 		);
+
+		// Inject indicator JS into body (this doesn't need to be cloned to auxiliary windows)
+		if (indicatorJS) {
+			html = html.replace(/(<\/body>)/, indicatorJS + "\n</body>");
+		}
+
 		try {
 			await fs.promises.writeFile(htmlPath, html, "utf-8");
 		} catch (e) {
@@ -210,6 +216,11 @@ function activate(context) {
 			""
 		);
 		html = html.replace(/<!-- !! VSCODE-CUSTOM-CSS-SESSION-ID [\w-]+ !! -->\n*/g, "");
+		// Clear indicator JS that was injected into body
+		html = html.replace(
+			/<script>\/\* eslint-env browser \*\/[\s\S]*?__CUSTOM_CSS_JS_INDICATOR_CLS[\s\S]*?<\/script>\n*/g,
+			""
+		);
 		return html;
 	}
 
@@ -304,5 +315,5 @@ function activate(context) {
 exports.activate = activate;
 
 // this method is called when your extension is deactivated
-function deactivate() { }
+function deactivate() {}
 exports.deactivate = deactivate;


### PR DESCRIPTION
## Problem

Auxiliary windows in VS Code (e.g., **New Chat Window**, detached panels) are created by cloning the `<head>` element from the workbench HTML. Because the extension was injecting custom CSS/JS imports before `</html>`, these auxiliary windows never received the custom styles.

## Solution

- **Inject CSS/JS imports into `<head>`** so that auxiliary windows clone the styles correctly.
- **Inject the statusbar indicator JS separately into `<body>`** to preserve the original behavior of running after the main workbench JS has finished loading (see commit `6eed49f`), and to avoid unnecessarily cloning the indicator into auxiliary windows.
- **Update `clearExistingPatches()`** to also strip the indicator `<script>` tag from `<body>` during uninstall/reinstall.

## Notes

Custom JS files listed in `vscode_custom_css.imports` will now execute during `<head>` parsing rather than after the full page load. Scripts that rely on the DOM being ready should use `DOMContentLoaded` or similar guards.